### PR TITLE
Normal and ID Pastebin url support added

### DIFF
--- a/Pastebin Downloader.py
+++ b/Pastebin Downloader.py
@@ -2,12 +2,18 @@ import requests
 
 print("Welcome to Pastebin downloader! Made by Azure#0263 / Lee Everrett")
 print("No more copy and pasting into a text file manually!")
-print("To start, please enter the url to a pastebin (raw)")
-print("")
-pastebin_url = input("Url: ")
-filename = input("Name of text file (e.g Downloaded pastebin): ")
+print("To start, please enter the url to a pastebin or the id. \n")
 
-r = requests.get(pastebin_url)
+pastebin_raw_url = input("URL / ID: ")
+filename = input("Name of text file (e.g Downloaded pastebin): ")
+pastebin_id = pastebin_raw_url.split("/")[-1]
+
+if len(pastebin_raw_url.split("/")) == 1:
+  pastebin_raw_url = 'https://pastebin.com/raw/{}'.format(pastebin_id)
+elif pastebin_raw_url.split("/")[-2] != "raw":
+  pastebin_raw_url = 'https://pastebin.com/raw/{}'.format(pastebin_id)
+
+r = requests.get(pastebin_raw_url)
 f = open(f'{filename}.txt', 'a+')
 f.write(r.text)
 print(f"Text file {filename}.txt has been made!")

--- a/README.md
+++ b/README.md
@@ -2,15 +2,28 @@
 Downloads pastebins 
 
 
-Requirements:
-Python 3.6
-Requests
+**Requirements:**
+ - Python 3.6
+ - Requests
 
 This tool is used as a way to stop yourself from having to copy and paste things from pastebin and put them in a text file yourself.
 Can work with other sites that are like Pastebin
 
-Please remember to make your link a /raw/ link.
-e.g 
-http://pastebin.com/raw/asdiojamdksu
+You can use the Pastebin link or ID, for example:
+
+**/raw/ URL**
+```
+https://pastebin.com/raw/hUgrbrSY
+```
+
+**normal Pastebin URL**
+```
+https://pastebin.com/hUgrbrSY
+```
+
+**Pastebin ID**
+```
+hUgrbrSY
+```
 
 Have fun!


### PR DESCRIPTION
Now the script accepts this types of URL to download the Pastebin:
- ```https://pastebin.com/raw/hUgrbrSY``` (The raw URL of a Pastebin)
- ```https://pastebin.com/hUgrbrSY``` (The normal URL of a Pastebin)
- ```hUgrbrSY``` (The ID of a Pastebin, included in the URL)

Additionally, I've updated the README.md file to include this information.